### PR TITLE
Adds server support to expose odgi files using SPARQL over http

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,18 @@ See more example queries in the queries directory. You can run them like this.
 ./sparql_odgi.py test/t.odgi "$(cat queries/selectAllSteps.rq)"
 ```
 
+# Setting up server to run SPARQL over HTTP
+
+The following command will expose the `test/t.odgi` file for querying at `http://127.0.0.1:5001/sparql`.
+```bash
+./sparql_server.py test/t.odgi
+```
+
+If running through docker, expose the `5001` port.
+```
+docker run -p 5001:5001 -it spodgi
+```
+
 # Variation Graphs as RDF/semantic graphs.
 
 The modelling is following what is described in the [vg](https://github.com/vgteam/vg) repository. 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,9 @@ setup(
     python_requires='>=3.6',
     install_requires=[
         "Click>=7.0.0",
-        "rdflib>=5.0.0"
+        "rdflib>=5.0.0",
+	"requests",
+	"flask"
     ],
     setup_requires=[
     

--- a/sparql_server.py
+++ b/sparql_server.py
@@ -1,0 +1,56 @@
+from flask import Flask, request, jsonify, Response
+from spodgi import OdgiStore
+import sys
+import json
+
+import rdflib
+from rdflib.namespace import RDF
+from rdflib.store import Store
+from rdflib import Graph
+from rdflib import plugin
+
+def resultformat_to_mime(format): 
+    if format=='xml': return "application/sparql-results+xml"
+    if format=='json': return "application/sparql-results+json"
+    if format=='html': return "text/html"
+    return "text/plain"
+
+def get_format_and_mimetype(accept_headers, output_format):
+
+    if not output_format:
+        output_format = "xml"
+        if "text/html" in a:
+            output_format = "html"
+        if "application/sparql-results+json" in a:
+            output_format = "json"
+        
+    mimetype = resultformat_to_mime(output_format)
+    mimetype = request.values.get("force-accept", mimetype)
+
+    return output_format, mimetype
+
+app = Flask(__name__)
+@app.route('/sparql')
+def sparql_endpoint():
+    query = request.args.get('query')
+
+    accept_headers = request.headers["Accept"]
+    output_format = request.values.get("output", None)
+
+    output_format, mimetype = get_format_and_mimetype(accept_headers, output_format)
+
+    res = spodgi.query(query).serialize(format = output_format)
+    
+    response = Response(res)
+    response.headers["Content-Type"] = mimetype
+    return response
+
+if __name__ == '__main__':
+
+    odgifile = sys.argv[1]
+    plugin.register('OdgiStore', Store,'spodgi.OdgiStore', 'OdgiStore')
+    s = plugin.get('OdgiStore', Store)(base='http://example.org/vg/')
+    spodgi = Graph(store=s)
+    spodgi.open(odgifile, create=False)
+
+    app.run(host='0.0.0.0',port=5001, debug = True)

--- a/sparql_server.py
+++ b/sparql_server.py
@@ -1,3 +1,4 @@
+#!/usr/bin/python3
 from flask import Flask, request, jsonify, Response
 from spodgi import OdgiStore
 import sys
@@ -53,4 +54,4 @@ if __name__ == '__main__':
     spodgi = Graph(store=s)
     spodgi.open(odgifile, create=False)
 
-    app.run(host='0.0.0.0',port=5001, debug = True)
+    app.run(host='0.0.0.0',port=5001)


### PR DESCRIPTION
Fixes #12 

The rdflib-web module is outdated and did not work with python3.7(version). So I thought the best way forward was to set up a flask server ourselves that would support SPARQL queries. I've taken inspiration from the rdflib-web library to support different types of format for input and returning the response. The following are the major contributions 

1. A flask server application that takes an `odgi` file as input and exposes a sparql endpoint with support for XML, JSON, HTML.
2. Tested the server with the following clients
   * https://github.com/RDFLib/sparqlwrapper
   * https://jena.apache.org/documentation/fuseki2/soh.html
3. Added documentation for deploying the server with/without docker
4. Added requests library as a requirement because spodgi couldn't run without it. 